### PR TITLE
Implement new Message ID system & more robust database security

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -36,7 +36,7 @@ service cloud.firestore {
                     && exists(/databases/$(database)/documents/users/$(request.resource.data.from))
                     // > Check if the correct key is used
                     && request.resource.data.key ==
-                    get(/databases/$(database)/documents/users/$(request.resource.data.to)).key;
+                    get(/databases/$(database)/documents/users/$(request.resource.data.to)).data.key;
       allow update: if false;
       // Yearbook methodology - sent messages become the property of the recipient
       allow delete: if resource.data.to == request.auth.uid;

--- a/firestore.rules
+++ b/firestore.rules
@@ -9,8 +9,8 @@ service cloud.firestore {
       allow create: if request.resource.data.from == request.auth.uid
                     && exists(/databases/$(database)/documents/users/$(request.resource.data.to))
                     && exists(/databases/$(database)/documents/users/$(request.resource.data.from))
-                    && message.split('.')[0] == request.resource.data.from
-                    && message.split('.')[1] == request.resource.data.to
+                    && message.split('-')[0] == request.resource.data.from
+                    && message.split('-')[1] == request.resource.data.to
                     && !exists(/databases/$(database)/documents/messages/$(message))
                     && request.resource.data.contents.size() <= 5000;
       allow update: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,9 +4,14 @@ service cloud.firestore {
     match /messages/{message} {
       // 1st condition: Allow you to read messages sent to you for purposes of viewing.component
       // 2nd condition: Allow you to read messages sent by you for purposes of checkForMessage()
-      allow read: if resource.data.to == request.auth.uid || resource.data.from == request.auth.uid;
+      allow get: if resource.data.to == request.auth.uid || resource.data.from == request.auth.uid;
+      allow list: if resource.data.to == request.auth.uid;
       allow create: if request.resource.data.from == request.auth.uid
                     && exists(/databases/$(database)/documents/users/$(request.resource.data.to))
+                    && exists(/databases/$(database)/documents/users/$(request.resource.data.from))
+                    && message.split('.')[0] == request.resource.data.from
+                    && message.split('.')[1] == request.resource.data.to
+                    && !exists(/databases/$(database)/documents/messages/$(message))
                     && request.resource.data.contents.size() <= 5000;
       allow update: if false;
       allow delete: if resource.data.to == request.auth.uid;

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,7 +4,7 @@ service cloud.firestore {
     match /messages/{message} {
       // 1st condition: Allow you to read messages sent to you for purposes of viewing.component
       // 2nd condition: Allow you to read messages sent by you for purposes of checkForMessage()
-      allow get: if resource.data.to == request.auth.uid || resource.data.from == request.auth.uid;
+      allow get: if message.split('-')[0] == request.auth.uid && request.auth.uid != null;
       allow list: if resource.data.to == request.auth.uid;
       allow create: if request.resource.data.from == request.auth.uid
                     && exists(/databases/$(database)/documents/users/$(request.resource.data.to))

--- a/firestore.rules
+++ b/firestore.rules
@@ -21,8 +21,10 @@ service cloud.firestore {
                     // > Regex to match hex color code format (#AABBCC)
                     && request.resource.data.backColor.matches('^#(?:[0-9a-fA-F]{3}){1,2}$')
                     && request.resource.data.fontColor.matches('^#(?:[0-9a-fA-F]{3}){1,2}$')
+                    // > Regex string fields to reject if they're only whitespace or blank
                     && request.resource.data.fontFamily.matches('\\S+')
                     && request.resource.data.key.matches('\\S+')
+                    // Verify variable types
                     && request.resource.data.isRead is bool
                     && request.resource.data.timestamp is timestamp
                     && request.resource.data.year is number

--- a/firestore.rules
+++ b/firestore.rules
@@ -12,7 +12,9 @@ service cloud.firestore {
                     && message.split('-')[0] == request.resource.data.from
                     && message.split('-')[1] == request.resource.data.to
                     && !exists(/databases/$(database)/documents/messages/$(message))
-                    && request.resource.data.contents.size() <= 5000;
+                    && request.resource.data.contents.size() <= 5000
+                    && request.resource.data.key ==
+                    get(/databases/$(database)/documents/users/$(request.resource.data.to)).key;
       allow update: if false;
       allow delete: if resource.data.to == request.auth.uid;
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,12 +7,12 @@ service cloud.firestore {
       allow get: if message.split('-')[0] == request.auth.uid && request.auth.uid != null;
       allow list: if resource.data.to == request.auth.uid;
       allow create: if request.resource.data.from == request.auth.uid
-                    && exists(/databases/$(database)/documents/users/$(request.resource.data.to))
-                    && exists(/databases/$(database)/documents/users/$(request.resource.data.from))
                     && message.split('-')[0] == request.resource.data.from
                     && message.split('-')[1] == request.resource.data.to
-                    && !exists(/databases/$(database)/documents/messages/$(message))
                     && request.resource.data.contents.size() <= 5000
+                    && !exists(/databases/$(database)/documents/messages/$(message))
+                    && exists(/databases/$(database)/documents/users/$(request.resource.data.to))
+                    && exists(/databases/$(database)/documents/users/$(request.resource.data.from))
                     && request.resource.data.key ==
                     get(/databases/$(database)/documents/users/$(request.resource.data.to)).key;
       allow update: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,7 @@ service cloud.firestore {
       allow get: if message.split('-')[0] == request.auth.uid && request.auth.uid != null;
       // Yearbook methodology - only the recipient may see the messages
       allow list: if resource.data.to == request.auth.uid;
-      allow create: if request.resource.data.hasAll(['backColor', 'contents', 'fontColor', 'fontFamily',
+      allow create: if request.resource.data.keys().hasAll(['backColor', 'contents', 'fontColor', 'fontFamily',
             				'from', 'isRead', 'key', 'fromName', 'fromPic', 'timestamp', 'to', 'year'])
                     // Param Validity
                     // > Enforce Message ID format of <fromUID>-<toUID>

--- a/firestore.rules
+++ b/firestore.rules
@@ -6,13 +6,34 @@ service cloud.firestore {
       // 2nd condition: Allow you to read messages sent by you for purposes of checkForMessage()
       allow get: if message.split('-')[0] == request.auth.uid && request.auth.uid != null;
       allow list: if resource.data.to == request.auth.uid;
-      allow create: if request.resource.data.from == request.auth.uid
+      allow create: if request.resource.data.hasAll(['backColor', 'contents', 'fontColor', 'fontFamily',
+            				'from', 'isRead', 'key', 'fromName', 'fromPic', 'timestamp', 'to', 'year'])
+                    // Param Validity
+                    // > Enforce Message ID format of <fromUID>-<toUID>
                     && message.split('-')[0] == request.resource.data.from
                     && message.split('-')[1] == request.resource.data.to
+                    // > Enforce max message length
                     && request.resource.data.contents.size() <= 5000
+                    // Data Validity
+                    // > Regex string fields to reject if they're only whitespace or blank
+                    && request.resource.data.contents.matches('\\S+')
+                    // > Regex to match hex color code format (#AABBCC)
+                    && request.resource.data.backColor.matches('^#(?:[0-9a-fA-F]{3}){1,2}$')
+                    && request.resource.data.fontColor.matches('^#(?:[0-9a-fA-F]{3}){1,2}$')
+                    && request.resource.data.fontFamily.matches('\\S+')
+                    && request.resource.data.key.matches('\\S+')
+                    && request.resource.data.isRead is bool
+                    && request.resource.data.timestamp is timestamp
+                    && request.resource.data.year is number
+                    && request.resource.data.year >= 2020
+                    // Authentication
+                    && request.resource.data.from == request.auth.uid
+                    // > Check to make sure 'from' hasn't already sent a message to 'to'
+                    // > One message per sender-recipient pair enforced by message ID format
                     && !exists(/databases/$(database)/documents/messages/$(message))
                     && exists(/databases/$(database)/documents/users/$(request.resource.data.to))
                     && exists(/databases/$(database)/documents/users/$(request.resource.data.from))
+                    // > Check if the correct key is used
                     && request.resource.data.key ==
                     get(/databases/$(database)/documents/users/$(request.resource.data.to)).key;
       allow update: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,9 +2,10 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /messages/{message} {
-      // 1st condition: Allow you to read messages sent to you for purposes of viewing.component
-      // 2nd condition: Allow you to read messages sent by you for purposes of checkForMessage()
+      // Getting (or searching for) a message is permitted if the user is the sender
+      // Used in MsgIoService.checkForMessage()
       allow get: if message.split('-')[0] == request.auth.uid && request.auth.uid != null;
+      // Yearbook methodology - only the recipient may see the messages
       allow list: if resource.data.to == request.auth.uid;
       allow create: if request.resource.data.hasAll(['backColor', 'contents', 'fontColor', 'fontFamily',
             				'from', 'isRead', 'key', 'fromName', 'fromPic', 'timestamp', 'to', 'year'])
@@ -37,12 +38,15 @@ service cloud.firestore {
                     && request.resource.data.key ==
                     get(/databases/$(database)/documents/users/$(request.resource.data.to)).key;
       allow update: if false;
+      // Yearbook methodology - sent messages become the property of the recipient
       allow delete: if resource.data.to == request.auth.uid;
     }
     match /users/{user} {
+      // Wide exception necessary for key verification
       allow get: if request.auth != null;
+      // Prevent scraping of all of the users
       allow list: if false;
-      // Only write to your own user info
+      // Only write to user's own info
       allow write: if request.auth.uid == user;
     }
   }

--- a/src/app/core/msg-io.service.ts
+++ b/src/app/core/msg-io.service.ts
@@ -38,7 +38,7 @@ export class MsgIoService {
       throw new Error('Recipient UID was not provided');
     } else if (typeof message.contents === 'undefined' || !message.contents) {
       throw new Error('Message contents were not provided');
-    } else if (/\S+/.test(message.contents)) {
+    } else if (!/\S+/.test(message.contents)) {
       // Ensure messages does not solely consist of whitespace
       throw new Error('Message contents cannot solely consist of whitespace/blanks');
     } else if (typeof message.backColor === 'undefined' || !message.backColor) {

--- a/src/app/core/msg-io.service.ts
+++ b/src/app/core/msg-io.service.ts
@@ -115,7 +115,7 @@ export class MsgIoService {
    */
   async checkForMessage(toUID: string): Promise<boolean> {
     const msgRef: AngularFirestoreDocument<VirtrolioDocument> = await this.afs.collection('messages')
-      .doc(this.authService.uid() + '.' + toUID);
+      .doc(this.authService.uid() + '-' + toUID);
     const msgDoc: VirtrolioDocument = await msgRef.valueChanges().pipe(take(1)).toPromise();
     return !!msgDoc;
     // const messages = await this.afs.collection('messages', ref => ref
@@ -171,7 +171,7 @@ export class MsgIoService {
       };
 
       // Send the message
-      const msgRef = this.messagesCollection.doc(this.authService.uid() + '.' + message.to);
+      const msgRef = this.messagesCollection.doc(this.authService.uid() + '-' + message.to);
       await msgRef.set(message).catch(error => {
         AuthService.displayError(error);
       });

--- a/src/app/core/msg-io.service.ts
+++ b/src/app/core/msg-io.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, SecurityContext } from '@angular/core';
-import { AngularFirestore, AngularFirestoreCollection, AngularFirestoreDocument } from '@angular/fire/firestore';
+import { AngularFirestore, AngularFirestoreCollection } from '@angular/fire/firestore';
 import { VirtrolioDocument, VirtrolioMessage, VirtrolioMessageTemplate } from '../shared/interfaces';
 
 import * as firebase from 'firebase';
@@ -114,20 +114,16 @@ export class MsgIoService {
    * @returns true - If the current user has already signed the virtrolio of toUID.
    */
   async checkForMessage(toUID: string): Promise<boolean> {
-    const msgRef: AngularFirestoreDocument<VirtrolioDocument> = await this.afs.collection('messages')
-      .doc(this.authService.uid() + '-' + toUID);
-    const msgDoc: VirtrolioDocument = await msgRef.valueChanges().pipe(take(1)).toPromise();
-    return !!msgDoc;
-    // const messages = await this.afs.collection('messages', ref => ref
-    //   .where('from', '==', this.authService.uid()).where('to', '==', toUID))
-    //   .valueChanges().pipe(take(1)).toPromise().catch(error => {
-    //     AuthService.displayError(error);
-    //   });
-    // if (messages) {
-    //   return messages.length !== 0;
-    // } else {
-    //   return false;
-    // }
+    const messages = await this.afs.collection('messages', ref => ref
+      .where('from', '==', this.authService.uid()).where('to', '==', toUID))
+      .valueChanges().pipe(take(1)).toPromise().catch(error => {
+        AuthService.displayError(error);
+      });
+    if (messages) {
+      return messages.length !== 0;
+    } else {
+      return false;
+    }
   }
 
   /**
@@ -171,7 +167,7 @@ export class MsgIoService {
       };
 
       // Send the message
-      const msgRef = this.messagesCollection.doc(this.authService.uid() + '-' + message.to);
+      const msgRef = this.messagesCollection.doc(this.authService.uid() + '.' + message.to);
       await msgRef.set(message).catch(error => {
         AuthService.displayError(error);
       });

--- a/src/app/core/msg-io.service.ts
+++ b/src/app/core/msg-io.service.ts
@@ -167,7 +167,8 @@ export class MsgIoService {
         isRead: false,
         year: MsgIoService.currentYear,
         fromName: await this.authService.displayName(),
-        fromPic: await this.authService.profilePictureLink()
+        fromPic: await this.authService.profilePictureLink(),
+        key
       };
 
       // Send the message

--- a/src/app/core/msg-io.service.ts
+++ b/src/app/core/msg-io.service.ts
@@ -167,7 +167,8 @@ export class MsgIoService {
       };
 
       // Send the message
-      await this.messagesCollection.add(message).catch(error => {
+      const msgRef = this.messagesCollection.doc(this.authService.uid() + '.' + message.to);
+      await msgRef.set(message).catch(error => {
         AuthService.displayError(error);
       });
     } else {

--- a/src/app/core/msg-io.service.ts
+++ b/src/app/core/msg-io.service.ts
@@ -38,8 +38,8 @@ export class MsgIoService {
       throw new Error('Recipient UID was not provided');
     } else if (typeof message.contents === 'undefined' || !message.contents) {
       throw new Error('Message contents were not provided');
-    } else if (!message.contents.replace(/\s/g, '').length) {
-      // Check if a message where all of the whitespace is deleted is blank which = entire message is whitespace
+    } else if (/\S+/.test(message.contents)) {
+      // Ensure messages does not solely consist of whitespace
       throw new Error('Message contents cannot solely consist of whitespace/blanks');
     } else if (typeof message.backColor === 'undefined' || !message.backColor) {
       throw new Error('Background color was not provided');

--- a/src/app/core/msg-io.service.ts
+++ b/src/app/core/msg-io.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, SecurityContext } from '@angular/core';
-import { AngularFirestore, AngularFirestoreCollection } from '@angular/fire/firestore';
+import { AngularFirestore, AngularFirestoreCollection, AngularFirestoreDocument } from '@angular/fire/firestore';
 import { VirtrolioDocument, VirtrolioMessage, VirtrolioMessageTemplate } from '../shared/interfaces';
 
 import * as firebase from 'firebase';
@@ -114,16 +114,20 @@ export class MsgIoService {
    * @returns true - If the current user has already signed the virtrolio of toUID.
    */
   async checkForMessage(toUID: string): Promise<boolean> {
-    const messages = await this.afs.collection('messages', ref => ref
-      .where('from', '==', this.authService.uid()).where('to', '==', toUID))
-      .valueChanges().pipe(take(1)).toPromise().catch(error => {
-        AuthService.displayError(error);
-      });
-    if (messages) {
-      return messages.length !== 0;
-    } else {
-      return false;
-    }
+    const msgRef: AngularFirestoreDocument<VirtrolioDocument> = await this.afs.collection('messages')
+      .doc(this.authService.uid() + '.' + toUID);
+    const msgDoc: VirtrolioDocument = await msgRef.valueChanges().pipe(take(1)).toPromise();
+    return !!msgDoc;
+    // const messages = await this.afs.collection('messages', ref => ref
+    //   .where('from', '==', this.authService.uid()).where('to', '==', toUID))
+    //   .valueChanges().pipe(take(1)).toPromise().catch(error => {
+    //     AuthService.displayError(error);
+    //   });
+    // if (messages) {
+    //   return messages.length !== 0;
+    // } else {
+    //   return false;
+    // }
   }
 
   /**

--- a/src/app/shared/interfaces.ts
+++ b/src/app/shared/interfaces.ts
@@ -16,6 +16,7 @@ export interface VirtrolioDocument extends VirtrolioMessageTemplate {
   timestamp: Timestamp;
   fromName: string;
   fromPic: string;
+  key: string;
 }
 
 export interface VirtrolioMessage extends VirtrolioDocument {

--- a/src/app/shared/interfaces.ts
+++ b/src/app/shared/interfaces.ts
@@ -11,12 +11,12 @@ export class VirtrolioMessageTemplate {
 
 export interface VirtrolioDocument extends VirtrolioMessageTemplate {
   from: string;
-  isRead: boolean;
-  year: number;
-  timestamp: Timestamp;
   fromName: string;
   fromPic: string;
+  isRead: boolean;
   key: string;
+  timestamp: Timestamp;
+  year: number;
 }
 
 export interface VirtrolioMessage extends VirtrolioDocument {


### PR DESCRIPTION
Currently, the Firestore rules do not explicitly prevent a user from sending multiple messages to the same person - the checks are all clientside, which is not secure.
To prevent this, the Message ID generation has been changed from random strings to a fixed format of the sender and recipient UIDs concatenated with a hyphen. Since it is impossible to have two documents in Firestore with the same ID and since Firestore now enforces this new Message ID format, this now prevents multiple messages from being sent without one being deleted.
In addition to verifying that all new messages meet this requirement, other changes were also made:
- All of the checks from `MsgIoService.verifyMessage()` have been added to the Firestore backend with the exception of checking for valid font families. @janakitti, please add a backup font in `viewing.component` in case a message with an invalid font is received.
- The regex checking for blank messages has been changed to be simpler in both `firestore.rules` and `MsgIoService.verifyMessage()`.
- `MsgIoService.sendMessage()` now uses the new Message ID format.
- Firestore will not allow a message to be sent without a valid key (currently also only checked clientside)