### PR TITLE
Add check allowing only Beta Testers to access the website + Better Error Handling

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { PendingChangesGuard } from './core/pending-changes.guard';
 import { RouterModule, Routes } from '@angular/router';
 // Pages
 import { AboutComponent } from './pages/about/about.component';
+import { AccessDeniedBetaComponent } from './pages/access-denied-beta/access-denied-beta.component';
 import { AccessDeniedComponent } from './pages/access-denied/access-denied.component';
 import { ContactComponent } from './pages/contact/contact.component';
 import { FaqComponent } from './pages/faq/faq.component';
@@ -33,6 +34,7 @@ const routes: Routes = [
     resolve: { user: LoginResolver }
   },
   { path: 'about', component: AboutComponent },
+  { path: 'access-denied-beta', component: AccessDeniedBetaComponent },
   { path: 'access-denied', component: AccessDeniedComponent },
   { path: 'contact', component: ContactComponent },
   { path: 'faq', component: FaqComponent },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { AppComponent } from './app.component';
 import { CoreModule } from './core/core.module';
 // Pages
 import { AboutComponent } from './pages/about/about.component';
+import { AccessDeniedBetaComponent } from './pages/access-denied-beta/access-denied-beta.component';
 import { AccessDeniedComponent } from './pages/access-denied/access-denied.component';
 import { ContactComponent } from './pages/contact/contact.component';
 import { FaqComponent } from './pages/faq/faq.component';
@@ -48,6 +49,7 @@ import { PendingChangesGuard } from './core/pending-changes.guard';
 
 @NgModule({
   declarations: [
+    AccessDeniedBetaComponent,
     AccessDeniedComponent,
     AppComponent,
     AboutComponent,

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -86,7 +86,8 @@ export class AuthService {
   /**
    * Logs the user into the website using Firebase Authentication and the specified provider.
    * User data creation is handled ONLY for desktop devices.
-   * Any page calling login **must** call AuthService.redirectLoginUserCreation() in ngOnInit() of the page that it redirects to.
+   * Any page calling login **must** call AuthService.redirectLoginUserCreation() in ngOnInit() of the page that it redirects to, which is
+   * the routeTo param.
    * Otherwise, mobile users will not be able to create a user.
    * Upon login, the user will be redirected to a new page as defined in routeTo.
    * @param routeTo - The routerLink that the user will be redirected to on a successful login.

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -221,7 +221,13 @@ export class AuthService {
     // user will be null if signInWithRedirect wasn't called right before
     if (userCredentials.user) {
       await this.createUser(userCredentials.user).catch(error => {
-        return this.errorLogout(error);
+        if (error.message === AuthService.notBetaErrorMessage) {
+          return this.afa.signOut().then(() => {
+            return this.router.navigate([ '/access-denied-beta' ]);
+          });
+        } else {
+          return this.errorLogout(error);
+        }
       });
     }
   }

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -160,6 +160,7 @@ export class AuthService {
   /**
    * Creates a new VirtrolioUser document in the 'users' collection of the database only if the document for the
    * currently logged in user doesn't exist.
+   * @param user: The user object returned by the Firebase Authentication login process.
    * @throws ReferenceError - If the Firestore documents for the user or list of beta testers is missing
    * @throws Error - If a write to Firestore fails
    */

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -82,7 +82,7 @@ export class AuthService {
    */
   errorLogout(error) {
     AuthService.displayError(error);
-    return this.afa.signOut().then(() => this.router.navigate([ '/access-denied' ]));
+    return this.afa.signOut().then(() => this.router.navigate([ '/access-denied' ])).catch(soError => AuthService.displayError(soError));
   }
 
   /**
@@ -120,17 +120,16 @@ export class AuthService {
             return this.router.navigate([ routeTo ], { queryParams });
           });
         } else {
-          AuthService.displayError('Null User Credentials on login: ' + userCredentials);
-          return this.router.navigate([ '/' ]);
+          return this.errorLogout('Null User Credentials on login: ' + userCredentials);
         }
       }).catch(error => {
         if (error.message === AuthService.notBetaErrorMessage) {
           return this.afa.signOut().then(() => {
             return this.router.navigate([ '/access-denied-beta' ]);
           });
+        } else {
+          return this.errorLogout(error);
         }
-        AuthService.displayError(error);
-        return this.router.navigate([ '/access-denied' ]);
       });
     } else { // Device is phone/tablet, so use sign-in with redirect
       const redirectPath = AuthService.parseQueryParams(routeTo, queryParams);
@@ -219,7 +218,7 @@ export class AuthService {
     // user will be null if signInWithRedirect wasn't called right before
     if (userCredentials.user) {
       await this.createUser(userCredentials.user).catch(error => {
-        AuthService.displayError(error);
+        return this.errorLogout(error);
       });
     }
   }

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -263,7 +263,7 @@ export class AuthService {
   }
 
   /**
-   * Same as profilePictureLink, except not async to avoid issues with the navbar loading too fast.
+   * Same as profilePictureLink, except not async to avoid the navbar trying to load the picture before the async call completes.
    * This method should <u>**NOT**</u> be called by anything except the navbar. Use profilePictureLink() instead.
    * @returns The URL to the user's profile picture.
    * @throws ReferenceError - If the user is not logged in

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -209,7 +209,9 @@ export class AuthService {
     const userCredentials = await this.afa.getRedirectResult();
     // user will be null if signInWithRedirect wasn't called right before
     if (userCredentials.user) {
-      await this.createUser(userCredentials.user);
+      await this.createUser(userCredentials.user).catch(error => {
+        AuthService.displayError(error);
+      });
     }
   }
 

--- a/src/app/core/auth.service.ts
+++ b/src/app/core/auth.service.ts
@@ -77,6 +77,15 @@ export class AuthService {
   }
 
   /**
+   * Displays an error using an alert, then logs the user out, and then redirects them to the access-denied page.
+   * @param error - The error to be displayed
+   */
+  errorLogout(error) {
+    AuthService.displayError(error);
+    return this.afa.signOut().then(() => this.router.navigate([ '/access-denied' ]));
+  }
+
+  /**
    * @returns The current User object.
    */
   getUser(): User {

--- a/src/app/core/navbar/navbar.component.css
+++ b/src/app/core/navbar/navbar.component.css
@@ -68,3 +68,10 @@
     padding-bottom: 1em;
   }
 }
+
+.navbar-beta-text {
+  font-family: Montserrat, sans-serif;
+  font-size: 0.6em;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0 0 0 0;
+}

--- a/src/app/core/navbar/navbar.component.html
+++ b/src/app/core/navbar/navbar.component.html
@@ -4,6 +4,7 @@
     <img alt="Virtrolio Logo" class="d-inline-block align-top" height="30" src="../../../assets/images/logo_inverted-circle.png"
          width="30">
     Virtrolio
+    <span class="navbar-beta-text">beta</span>
   </a>
   <!-- Hamburger menu on mobile -->
   <button aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation" class="navbar-toggler" data-target="#navbarNav"

--- a/src/app/pages/access-denied-beta/access-denied-beta.component.css
+++ b/src/app/pages/access-denied-beta/access-denied-beta.component.css
@@ -1,0 +1,28 @@
+#graphic {
+  height: 10em;
+}
+
+#title-text {
+  font-size: 2.5em;
+  text-align: center;
+}
+
+.subtitle-text {
+  font-size: large;
+  text-align: center;
+}
+
+/* Mobile */
+@media only screen and (max-width: 768px) {
+  #graphic {
+    height: 5em;
+  }
+
+  #title-text {
+    font-size: 2em;
+  }
+
+  #subtitle-text {
+    font-size: 1em;
+  }
+}

--- a/src/app/pages/access-denied-beta/access-denied-beta.component.html
+++ b/src/app/pages/access-denied-beta/access-denied-beta.component.html
@@ -1,0 +1,20 @@
+<div class="container vertical-center montserrat align-items-center">
+  <div class="row mx-3 mt-3">
+    <h1 class="display-4" id="title-text">Access Denied - Not a Beta Tester</h1>
+  </div>
+  <div class="row mx-3 col-md-7 justify-content-center">
+    <p class="subtitle-text">Oops! You tried to login to the beta website, but you aren't a beta tester!</p>
+    <p class="subtitle-text"><strong>If you are not a beta tester, please <a href="https://virtrolio.web.app">
+      click here</a> to use the public website.</strong></p>
+    <p class="subtitle-text">If you <strong>are</strong> a beta tester and are seeing this message, please follow
+      the instructions in the #instructions channel in the Beta Tester Discord to gain access. Message a
+    Software Developer if you continue to experience problems.</p>
+  </div>
+  <div class="row justify-content-center mx-3 mt-3">
+    <img alt="Padlock graphic" id="graphic" src="../../../assets/images/AccessDenied.svg">
+  </div>
+  <div class="row justify-content-center mt-5 mb-3">
+    <a class="btn btn-lg btn-primary mt-3 mx-3" role="button" href="https://virtrolio.web.app">Go to the Public Website</a>
+    <button class="btn btn-lg btn-secondary mt-3" routerLink="">Back to Beta Website</button>
+  </div>
+</div>

--- a/src/app/pages/access-denied-beta/access-denied-beta.component.spec.ts
+++ b/src/app/pages/access-denied-beta/access-denied-beta.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccessDeniedBetaComponent } from './access-denied-beta.component';
+
+describe('AccessDeniedBetaComponent', () => {
+  let component: AccessDeniedBetaComponent;
+  let fixture: ComponentFixture<AccessDeniedBetaComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AccessDeniedBetaComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AccessDeniedBetaComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/access-denied-beta/access-denied-beta.component.ts
+++ b/src/app/pages/access-denied-beta/access-denied-beta.component.ts
@@ -1,0 +1,17 @@
+import { Component, OnInit } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+
+@Component({
+  selector: 'app-access-denied-beta',
+  templateUrl: './access-denied-beta.component.html',
+  styleUrls: ['./access-denied-beta.component.css']
+})
+export class AccessDeniedBetaComponent implements OnInit {
+
+  constructor(private title: Title) { }
+
+  ngOnInit(): void {
+    this.title.setTitle('Access Denied (Not a Beta Tester) | Virtrolio');
+  }
+
+}

--- a/src/app/pages/access-denied-beta/access-denied-beta.component.ts
+++ b/src/app/pages/access-denied-beta/access-denied-beta.component.ts
@@ -11,7 +11,7 @@ export class AccessDeniedBetaComponent implements OnInit {
   constructor(private title: Title) { }
 
   ngOnInit(): void {
-    this.title.setTitle('Access Denied (Not a Beta Tester) | Virtrolio');
+    this.title.setTitle('Beta Website Access Denied | Virtrolio');
   }
 
 }

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -30,6 +30,14 @@
           <!-- Changing this to 'true else MyVirtrolio' induces no flickering-->
           <p class="lead" id="bolded-body-text">Sign in below to create your own virtrolio!</p>
           <div class="row d-flex justify-content-center mt-4">
+            <p class="lead" style="color: red"><strong>WARNING: You are trying to sign into the beta website.</strong>
+            </p>
+            <p class="lead" style="color: red">This version of the website is only accessible to beta testers, and
+              contains features that are not fully functional yet.</p>
+            <p class="lead" style="color: red; font-weight: 600">If you are not a beta tester, please use the public
+              website instead, which you can access by <a href="https://virtrolio.web.app">clicking here</a>.</p>
+          </div>
+          <div class="row d-flex justify-content-center mt-4">
             <button (click)="authService.login('/my-virtrolio')" class="btn btn-outline-dark google-sign-in-btn"
                     type="button">
               <img alt="Google Logo" height="23" src="../../../assets/images/icons/google.svg" width="23">

--- a/src/app/shared/interfaces.ts
+++ b/src/app/shared/interfaces.ts
@@ -29,6 +29,10 @@ export interface VirtrolioUser {
   profilePic: string;
 }
 
+export interface BetaUsers {
+  users: string[];
+}
+
 export class Font {
   fontFamily: string;
   backupFont: string;


### PR DESCRIPTION
**A lot of changes, so please read carefully.**
There are two sets of changes in this PR - those that will get merged into `prod`, and those that will stay on `beta-main` without getting merged to `prod`.
The changes that apply only to `beta-main` will either be skipped during the next merge to prod or I'll manually revert them after merge.

---

## Changes applying only to `beta-main` (not getting merged into `prod`)
Commits [`7ef00df`](https://github.com/virtrolio/virtrolio-site/pull/74/commits/7ef00dfc4c37a8477995bb81d2f40d9b2afb650a) to [`8977493`](https://github.com/virtrolio/virtrolio-site/pull/74/commits/8977493b3ac1456b72e9780d6058facc2f9d9972) and commit [`7645485`](https://github.com/virtrolio/virtrolio-site/pull/74/commits/7645485fc7537fd40d3e2fff45a98d768f1b15c1)
- Addition of 'beta' to the navbar next to the logo
- Addition of a warning message above the sign-in button on the homepage
- I felt it wasn't necessary to add a warning to `signing-auth-redirect` because that would require a signing link directly to the beta website. Let me know what you think.
- Users will not be permitted to login unless their Firebase UID is present in the `users` array of the `beta/beta-testers` document in the Firestore database.
- Creation of a new page `access-denied-beta` providing more detailed information for users who get rejected by the new check for Beta Testers.
- Beta Testers can only be added to the document manually by Firebase Administrators. For the time being and for security reasons, I am going to limit the people who can add Beta Testers to myself and @janakitti.

## Changes applying to `prod` AND `beta-main`
Commits [`1d6f874`](https://github.com/virtrolio/virtrolio-site/pull/74/commits/1d6f874415c0f8fbe91b2256f4c252b774d439e9), [`e06b734`](https://github.com/virtrolio/virtrolio-site/pull/74/commits/e06b734144b992d46379b67e07d2d46f53b53de4) and commits [`a5de853`](https://github.com/virtrolio/virtrolio-site/pull/74/commits/a5de85353f9695c8d46386f5c97eb5afe3aab3fd) to [`12aeeaa`](https://github.com/virtrolio/virtrolio-site/pull/74/commits/12aeeaa67a62d7246e79925fe07f5eff7dfacaad)
- Creation of a new method `errorLogout()` that displays the error, logs the user out and redirects them to `access-denied` should an error occur during the login process.
- `errorLogout()` is now used to handle errors during `login()`, `redirectLoginUserCreation()` and `createUser()` to avoid users using the website without having their user document created in the Firestore database. 
- `createUser()` will now throw Errors instead of displaying them, since the catch statements in `login()`, `redirectLoginUserCreation()` and `createUser()` will now use `errorLogout()` to display the error and sign the user out.

---

**Please help test these changes by trying to sign-in on this branch to make sure the redirects work properly for you. If you want to test signing in with redirect as well, go to Line 116 of `auth.service.ts` and change the condition in the `if` statement to `false`.**