### PR TITLE
Check if the secrets are available before pushing to Firebase

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -10,9 +10,11 @@ jobs:
       - uses: actions/checkout@v2
       - run: npm ci && npm run build -- --prod
       - uses: FirebaseExtended/action-hosting-deploy@v0
+        if: ${{ env.FIREBASE_SERVICE_ACCOUNT_VIRTROLIO != null }} # Fix when a PR is opened from a fork
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_VIRTROLIO }}'
           projectId: virtrolio
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels
+          FIREBASE_SERVICE_ACCOUNT_VIRTROLIO: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_VIRTROLIO }}


### PR DESCRIPTION
This should fix the CI failing when a PR is opened from a fork. Github doesn't provide secrets if this is the case. 