### PR TITLE
Dismiss modals on component destruction

### DIFF
--- a/src/app/core/navbar/navbar.component.ts
+++ b/src/app/core/navbar/navbar.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { AuthService } from '../auth.service';
 
 import changelog from './changelog.json';
 import { AppComponent } from '../../app.component';
 import { ChangelogVersion } from '../../shared/interfaces/changelog';
+import { Event, NavigationStart, Router } from '@angular/router';
 
 declare var $: any;
 
@@ -12,16 +13,26 @@ declare var $: any;
   templateUrl: './navbar.component.html',
   styleUrls: [ './navbar.component.css' ]
 })
-export class NavbarComponent implements OnInit {
+export class NavbarComponent implements OnInit, OnDestroy {
   public changelog: ChangelogVersion[] = changelog;
   public beta = AppComponent.beta;
 
-  constructor(public authService: AuthService) { }
+  constructor(public authService: AuthService, private router: Router) {
+    router.events.subscribe((event: Event) => {
+      if (event instanceof NavigationStart) {
+        $('#changelog').modal('hide');
+      }
+    });
+  }
 
   ngOnInit(): void {
     /* Make hamburger menu collapse on item click */
     $('.navbar-nav>li>a').on('click', () => {
       $('.navbar-collapse').collapse('hide');
     });
+  }
+
+  ngOnDestroy(): void {
+    $('#changelog').modal('hide');
   }
 }

--- a/src/app/pages/my-virtrolio/my-virtrolio.component.ts
+++ b/src/app/pages/my-virtrolio/my-virtrolio.component.ts
@@ -1,10 +1,12 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AuthService } from '../../core/auth.service';
 import { CommonService } from '../../core/common.service';
 import { Router } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 import { SharingLinkService } from '../../core/sharing-link.service';
 import { MsgIoService } from '../../core/msg-io.service';
+
+declare var $: any;
 
 @Component({
   selector: 'app-my-virtrolio',
@@ -15,7 +17,7 @@ import { MsgIoService } from '../../core/msg-io.service';
 /**
  * 'My virtrolio.' Displays your virtrolio as a 'book' on screen and allows you to generate a sharing link.
  */
-export class MyVirtrolioComponent implements OnInit {
+export class MyVirtrolioComponent implements OnInit, OnDestroy {
   /** Default values */
   public link = 'Getting your link...';
   public linkReady = false;
@@ -37,6 +39,11 @@ export class MyVirtrolioComponent implements OnInit {
     });
     this.authService.redirectLoginUserCreation().catch(error => CommonService.displayError(error));
     this.navigator = window.navigator;
+  }
+
+  ngOnDestroy(): void {
+    $('#link-gen').modal('hide');
+    $('#send-message').modal('hide');
   }
 
   /**

--- a/src/app/pages/settings/settings.component.ts
+++ b/src/app/pages/settings/settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { AuthService } from '../../core/auth.service';
 import { MsgIoService } from '../../core/msg-io.service';
 import { take } from 'rxjs/operators';
@@ -11,7 +11,7 @@ declare var $: any;
   templateUrl: './settings.component.html',
   styleUrls: [ './settings.component.css' ]
 })
-export class SettingsComponent implements OnInit {
+export class SettingsComponent implements OnInit, OnDestroy {
   downloadMessagesData;
   downloadUserData;
   exportErrorText: string;
@@ -27,6 +27,12 @@ export class SettingsComponent implements OnInit {
 
   ngOnInit(): void {
     this.title.setTitle('Settings | Virtrolio');
+  }
+
+  ngOnDestroy(): void {
+    $('#download').modal('hide');
+    $('#download-error').modal('hide');
+    $('#delete-error').modal('hide');
   }
 
   /**
@@ -64,5 +70,4 @@ export class SettingsComponent implements OnInit {
       return;
     }
   }
-
 }

--- a/src/app/pages/signing/signing.component.ts
+++ b/src/app/pages/signing/signing.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit } from '@angular/core';
+import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { AuthService } from 'src/app/core/auth.service';
@@ -20,7 +20,7 @@ declare var $: any;
  * Controls user interaction with the signing box, updating the preview display and sending the message when they
  * click on the 'Send' button.
  */
-export class SigningComponent implements OnInit {
+export class SigningComponent implements OnInit, OnDestroy {
   public name = 'your friend';
   public sending = false;
   public embedLink = '';
@@ -51,6 +51,14 @@ export class SigningComponent implements OnInit {
     $('.popover-dismiss').popover({
       trigger: 'focus'
     });
+  }
+
+  ngOnDestroy(): void {
+    $('#submit-confirm').modal('hide');
+    $('#info').modal('hide');
+    $('#embed-help').modal('hide');
+    $('#embed-photo').modal('hide');
+    $('#signing-experience').modal('hide');
   }
 
   /**

--- a/src/app/pages/viewing/messages/messages.component.ts
+++ b/src/app/pages/viewing/messages/messages.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { ViewingService } from '../../../core/viewing.service';
 import { AuthService } from '../../../core/auth.service';
 import { ToastrService } from 'ngx-toastr';
@@ -8,13 +8,15 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { MessageModalComponent } from '../message-modal/message-modal.component';
 import { VirtrolioMessage } from '../../../shared/interfaces/messages';
 
+declare var $: any;
+
 @Component({
   selector: 'app-messages',
   templateUrl: './messages.component.html',
   styleUrls: [ './messages.component.css' ]
 })
 
-export class MessagesComponent implements OnInit {
+export class MessagesComponent implements OnInit, OnDestroy {
   messageList: VirtrolioMessage[] = [];
   oneMessage = 'messages';
 
@@ -46,6 +48,10 @@ export class MessagesComponent implements OnInit {
     const max = Math.max(r, g, b);
     const min = Math.min(r, g, b);
     return (max + min) / 2;
+  }
+
+  ngOnDestroy(): void {
+    $('#delete').modal('hide');
   }
 
   /**


### PR DESCRIPTION
There are two different ways of solving this problem. Please let me know which one makes the most sense.

The first way which I am using for all components is by implementing `ngOnDestroy()`, a lifecycle hook that triggers right before a component gets destroyed, such as when you navigate away from it.

The second way which I add as an extra step in `navbar.component.ts` is a subscription to the Angular Router's `NavigationStart` event, which triggers any time the user begins navigating. I need this alternate method in the navbar since it doesn't get destroyed when the user navigates to a different page, so I needed an alternate way of detecting this.

In both cases, jQuery handles the actual task of dismissing the modals.

One issue with this approach is that every new modal needs to have the dismiss code added to its component TypeScript file or else that specific modal won't dismiss - I can't have it done automatically for all modals. I don't have a good solution, so please comment if you have any ideas.

Closes virtrolio/issue-tracking#24