### PR TITLE
Switch from ng-bootstrap to ngx-bootstrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11152,6 +11152,11 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
+    "ngx-bootstrap": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-6.2.0.tgz",
+      "integrity": "sha512-5WKHo6/ltkenw4UyXZwED8rODCgp2RGbWurzYzZsF/gH1JO5SN7TJ+AL6kXYk6XM42sDA2WhN9Db+ZPNjiyHnA=="
+    },
     "ngx-cookie-service": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/ngx-cookie-service/-/ngx-cookie-service-12.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,14 +2591,6 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
-    "@ng-bootstrap/ng-bootstrap": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-9.1.1.tgz",
-      "integrity": "sha512-m31qKJylYueXm+a3YEoOfnrJYR1lovb7WgaQwvXQz3dDmtaYRX4n8aPeCMp1VrI7hFfFITKWo0GxPaI3JIFk4w==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
     "@ngtools/webpack": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "emoji-toolkit": "^6.5.1",
     "firebase": "^8.6.2",
     "jquery": "^3.6.0",
+    "ngx-bootstrap": "^6.2.0",
     "ngx-cookie-service": "^12.0.0",
     "ngx-device-detector": "^2.1.1",
     "ngx-markdown": "^12.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@angular/platform-browser": "~12.0.1",
     "@angular/platform-browser-dynamic": "~12.0.1",
     "@angular/router": "~12.0.1",
-    "@ng-bootstrap/ng-bootstrap": "^9.1.1",
     "aos": "^2.3.4",
     "bootstrap": "^4.6.0",
     "emoji-toolkit": "^6.5.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -45,6 +45,7 @@ import { TermsOfServiceComponent } from './pages/terms-of-service/terms-of-servi
 import { ViewingComponent } from './pages/viewing/viewing.component';
 // Services
 import { LoginResolver } from './core/login-resolver';
+import { ModalModule } from 'ngx-bootstrap/modal';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { PendingChangesGuard } from './core/pending-changes.guard';
 
@@ -97,6 +98,7 @@ import { PendingChangesGuard } from './core/pending-changes.guard';
         },
       },
     }),
+    ModalModule.forRoot(),
     NgbModule,
     ToastrModule.forRoot()
   ],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -46,7 +46,6 @@ import { ViewingComponent } from './pages/viewing/viewing.component';
 // Services
 import { LoginResolver } from './core/login-resolver';
 import { ModalModule } from 'ngx-bootstrap/modal';
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { PendingChangesGuard } from './core/pending-changes.guard';
 
 @NgModule({
@@ -99,7 +98,6 @@ import { PendingChangesGuard } from './core/pending-changes.guard';
       },
     }),
     ModalModule.forRoot(),
-    NgbModule,
     ToastrModule.forRoot()
   ],
   providers: [ CookieService, LoginResolver, PendingChangesGuard ],

--- a/src/app/pages/viewing/message-modal/message-modal.component.html
+++ b/src/app/pages/viewing/message-modal/message-modal.component.html
@@ -34,7 +34,7 @@
                 <img alt="bookmark" class="card-icon" src="../../../../assets/images/icons/bookmark-black.svg">
               </button>
             </a>
-            <button (click)="activeModal.close('Close click')" class="btn" type="button">
+            <button (click)="this.modalService.hide()" class="btn" type="button">
               <img alt="close" class="card-icon" src="../../../../assets/images/icons/exit.svg">
             </button>
           </td>

--- a/src/app/pages/viewing/message-modal/message-modal.component.ts
+++ b/src/app/pages/viewing/message-modal/message-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { ViewingService } from '../../../core/viewing.service';
+import { BsModalService } from 'ngx-bootstrap/modal';
 
 @Component({
   selector: 'app-message-modal',
@@ -9,7 +9,7 @@ import { ViewingService } from '../../../core/viewing.service';
 })
 export class MessageModalComponent implements OnInit {
 
-  constructor(public activeModal: NgbActiveModal, public viewService: ViewingService) { }
+  constructor(public viewService: ViewingService, public modalService: BsModalService) { }
 
   ngOnInit(): void {
   }

--- a/src/app/pages/viewing/messages/messages.component.ts
+++ b/src/app/pages/viewing/messages/messages.component.ts
@@ -4,9 +4,9 @@ import { AuthService } from '../../../core/auth.service';
 import { ToastrService } from 'ngx-toastr';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ViewportScroller } from '@angular/common';
-import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { MessageModalComponent } from '../message-modal/message-modal.component';
 import { VirtrolioMessage } from '../../../shared/interfaces/messages';
+import { BsModalService } from 'ngx-bootstrap/modal';
 
 declare var $: any;
 
@@ -21,7 +21,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
   oneMessage = 'messages';
 
   constructor(public viewService: ViewingService, public authService: AuthService, private route: ActivatedRoute,
-              private router: Router, private vps: ViewportScroller, private toastr: ToastrService, private modalService: NgbModal) {
+              private router: Router, private vps: ViewportScroller, private toastr: ToastrService, private modalService: BsModalService) {
   }
 
   /**
@@ -91,7 +91,7 @@ export class MessagesComponent implements OnInit, OnDestroy {
    */
   popupMessage(msg: VirtrolioMessage) {
     this.viewService.currentMessageModal = msg;
-    this.modalService.open(MessageModalComponent, { centered: true });
+    this.modalService.show(MessageModalComponent, { class: 'modal-dialog-centered' });
   }
 
   /**


### PR DESCRIPTION
In preparation for switching the whole app to `ngx-bootstrap`, we first need to get rid of the one place in the app where we used `ng-bootstrap`.