### PR TITLE
Add `npm run serve` command to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "serve": "ng serve --host 0.0.0.0",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
Adds `npm run serve` as a convenience alias for `ng serve --host 0.0.0.0`. Same as `npm start` which maps to `ng serve` except that it also opens the development server on your local network to allow for testing on other devices.